### PR TITLE
reporter/sentry: Bootstrap the error reporter

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,8 +1,6 @@
 package domain
 
 import (
-	"strings"
-
 	"github.com/upfluence/errors/base"
 	"github.com/upfluence/errors/stacktrace"
 )
@@ -18,7 +16,7 @@ func PackageDomain() Domain {
 func PackageDomainAtDepth(depth int) Domain {
 	var fn, _, _ = stacktrace.Caller(1 + depth).Location()
 
-	return Domain(packageName(fn))
+	return Domain(stacktrace.PackageName(fn))
 }
 
 func GetDomain(err error) Domain {
@@ -35,22 +33,4 @@ func GetDomain(err error) Domain {
 	}
 
 	return NoDomain
-}
-
-func packageName(name string) string {
-	// A prefix of "type." and "go." is a compiler-generated symbol that doesn't belong to any package.
-	// See variable reservedimports in cmd/compile/internal/gc/subr.go
-	if strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.") {
-		return ""
-	}
-
-	pathend := strings.LastIndex(name, "/")
-	if pathend < 0 {
-		pathend = 0
-	}
-
-	if i := strings.Index(name[pathend:], "."); i != -1 {
-		return name[:pathend+i]
-	}
-	return ""
 }

--- a/reporter/inhibit/reporter.go
+++ b/reporter/inhibit/reporter.go
@@ -1,0 +1,50 @@
+package inhibit
+
+import (
+	"sync"
+
+	"github.com/upfluence/errors/reporter"
+)
+
+type ErrorInhibitor interface {
+	Inhibit(error) bool
+}
+
+type ErrorInhibitorFunc func(error) bool
+
+func (fn ErrorInhibitorFunc) Inhibit(err error) bool { return fn(err) }
+
+type Reporter struct {
+	r reporter.Reporter
+
+	mu  sync.RWMutex
+	eis []ErrorInhibitor
+}
+
+func NewReporter(r reporter.Reporter, eis ...ErrorInhibitor) *Reporter {
+	return &Reporter{r: r, eis: eis}
+}
+
+func (r *Reporter) AddErrorInhibitors(eis ...ErrorInhibitor) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.eis = append(r.eis, eis...)
+}
+
+func (r *Reporter) Close() error { return r.r.Close() }
+
+func (r *Reporter) Report(err error, opts reporter.ReportOptions) {
+	r.mu.RLock()
+
+	for _, ei := range r.eis {
+		if ei.Inhibit(err) {
+			r.mu.RUnlock()
+			return
+		}
+	}
+
+	r.mu.RUnlock()
+
+	r.r.Report(err, opts)
+}

--- a/reporter/inhibit/reporter_test.go
+++ b/reporter/inhibit/reporter_test.go
@@ -1,0 +1,46 @@
+package inhibit
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/upfluence/errors/reporter"
+)
+
+type mockReporter struct {
+	called bool
+}
+
+func (*mockReporter) Close() error { return nil }
+func (mr *mockReporter) Report(error, reporter.ReportOptions) {
+	mr.called = true
+}
+
+func TestReporter(t *testing.T) {
+	var err1 = errors.New("foo")
+
+	for _, tt := range []struct {
+		err    error
+		called bool
+	}{
+		{err: err1},
+		{err: errors.New("bar"), called: true},
+	} {
+		var (
+			mr mockReporter
+
+			r = NewReporter(&mr)
+		)
+
+		r.AddErrorInhibitors(
+			ErrorInhibitorFunc(func(err error) bool { return err == err1 }),
+		)
+
+		r.Report(tt.err, reporter.ReportOptions{})
+
+		assert.Equal(t, tt.called, mr.called)
+	}
+
+}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -25,6 +25,8 @@ const (
 	ThriftRequestCallerKey  = "thrift.request.caller"
 )
 
+var NopReporter Reporter = nopReporter{}
+
 type ReportOptions struct {
 	Tags map[string]interface{}
 
@@ -36,3 +38,8 @@ type Reporter interface {
 
 	Report(error, ReportOptions)
 }
+
+type nopReporter struct{}
+
+func (nopReporter) Close() error                { return nil }
+func (nopReporter) Report(error, ReportOptions) {}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -2,6 +2,29 @@ package reporter
 
 import "io"
 
+const (
+	TransactionKey = "transaction"
+	DomainKey      = "domain"
+
+	UserEmailKey = "user.email"
+	UserIDKey    = "user.id"
+
+	RemoteIP   = "remote.ip"
+	RemotePort = "remote.port"
+
+	HTTPRequestPathKey   = "http.request.path"
+	HTTPRequestHostKey   = "http.request.host"
+	HTTPRequestProtoKey  = "http.request.proto"
+	HTTPRequestMethodKey = "http.request.method"
+
+	HTTPRequestHeaderKeyPrefix      = "http.request.headers."
+	HTTPRequestQueryValuesKeyPrefix = "http.request.query_values."
+
+	ThriftRequestMethodKey  = "thrift.request.method"
+	ThriftRequestServiceKey = "thrift.request.service"
+	ThriftRequestCallerKey  = "thrift.request.caller"
+)
+
 type ReportOptions struct {
 	Tags map[string]interface{}
 

--- a/reporter/sentry/options.go
+++ b/reporter/sentry/options.go
@@ -1,0 +1,61 @@
+package sentry
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/upfluence/errors/reporter"
+)
+
+var defaultOptions = Options{
+	SentryOptions: sentry.ClientOptions{Dsn: os.Getenv("SENTRY_DSN")},
+	TagWhitelist: toStringMap(
+		[]string{reporter.RemoteIP, reporter.RemotePort, reporter.DomainKey},
+	),
+	Timeout: time.Minute,
+	TagBlacklist: []func(string) bool{
+		stringEqual(reporter.TransactionKey),
+		stringEqual(reporter.UserEmailKey),
+		stringEqual(reporter.UserIDKey),
+		stringEqual(reporter.HTTPRequestProtoKey),
+		stringEqual(reporter.HTTPRequestPathKey),
+		stringEqual(reporter.HTTPRequestHostKey),
+		stringEqual(reporter.HTTPRequestMethodKey),
+		stringPrefix(reporter.HTTPRequestHeaderKeyPrefix),
+		stringPrefix(reporter.HTTPRequestQueryValuesKeyPrefix),
+	},
+}
+
+func stringEqual(x string) func(string) bool {
+	return func(y string) bool { return x == y }
+}
+
+func stringPrefix(x string) func(string) bool {
+	return func(y string) bool { return strings.HasPrefix(y, x) }
+}
+
+func toStringMap(vs []string) map[string]struct{} {
+	res := make(map[string]struct{}, len(vs))
+
+	for _, v := range vs {
+		res[v] = struct{}{}
+	}
+
+	return res
+}
+
+type Options struct {
+	SentryOptions sentry.ClientOptions
+	Timeout       time.Duration
+
+	TagWhitelist map[string]struct{}
+	TagBlacklist []func(string) bool
+}
+
+func (o Options) client() (*sentry.Client, error) {
+	return sentry.NewClient(o.SentryOptions)
+}
+
+type Option func(*Options)

--- a/reporter/sentry/reporter.go
+++ b/reporter/sentry/reporter.go
@@ -145,26 +145,8 @@ func extractStacktrace(err error, n int) *sentry.Stacktrace {
 }
 
 func splitQualifiedFunctionName(name string) (string, string) {
-	pkg := packageName(name)
+	pkg := stacktrace.PackageName(name)
 	return pkg, strings.TrimPrefix(name, pkg+".")
-}
-
-func packageName(name string) string {
-	// A prefix of "type." and "go." is a compiler-generated symbol that doesn't belong to any package.
-	// See variable reservedimports in cmd/compile/internal/gc/subr.go
-	if strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.") {
-		return ""
-	}
-
-	pathend := strings.LastIndex(name, "/")
-	if pathend < 0 {
-		pathend = 0
-	}
-
-	if i := strings.Index(name[pathend:], "."); i != -1 {
-		return name[:pathend+i]
-	}
-	return ""
 }
 
 func isInApp(absPath, module string) bool {

--- a/reporter/sentry/reporter.go
+++ b/reporter/sentry/reporter.go
@@ -1,23 +1,273 @@
 package sentry
 
 import (
+	"fmt"
+	"go/build"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 
+	"github.com/upfluence/errors/base"
+	"github.com/upfluence/errors/domain"
 	"github.com/upfluence/errors/reporter"
+	"github.com/upfluence/errors/stacktrace"
+	"github.com/upfluence/errors/tags"
 )
 
 type Reporter struct {
 	cl *sentry.Client
 
+	tagWhitelist map[string]struct{}
+	tagBlacklist []func(string) bool
+
 	timeout time.Duration
 }
 
+func NewReporter(os ...Option) (*Reporter, error) {
+	var opts = defaultOptions
+
+	for _, o := range os {
+		o(&opts)
+	}
+
+	cl, err := opts.client()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &Reporter{
+		cl:           cl,
+		tagWhitelist: opts.TagWhitelist,
+		timeout:      opts.Timeout,
+	}, nil
+}
+
 func (r *Reporter) Report(err error, opts reporter.ReportOptions) {
+	evt := r.buildEvent(err, opts)
+
+	if evt == nil {
+		return
+	}
+
+	r.cl.CaptureEvent(evt, nil, nil)
 }
 
 func (r *Reporter) Close() error {
 	r.cl.Flush(r.timeout)
+	return nil
+}
+
+func (r *Reporter) appendTag(k string, v interface{}, evt *sentry.Event) {
+	for _, fn := range r.tagBlacklist {
+		if fn(k) {
+			return
+		}
+	}
+
+	if _, ok := r.tagWhitelist[k]; ok {
+		evt.Tags[k] = stringifyTag(v)
+		return
+	}
+
+	evt.Contexts[k] = v
+}
+
+func (r *Reporter) buildEvent(err error, opts reporter.ReportOptions) *sentry.Event {
+	if err == nil {
+		return nil
+	}
+
+	ts := tags.GetTags(err)
+
+	for k, v := range opts.Tags {
+		if _, ok := ts[k]; !ok {
+			ts[k] = v
+		}
+	}
+
+	evt := sentry.NewEvent()
+
+	evt.Timestamp = time.Now()
+	evt.Message = err.Error()
+	evt.Transaction = transactionName(ts)
+	evt.User = buildUser(ts)
+	evt.Request = buildRequest(ts)
+
+	cause := base.UnwrapAll(err)
+
+	evt.Exception = []sentry.Exception{
+		{
+			Type:       fmt.Sprintf("%T", cause),
+			Value:      cause.Error(),
+			Module:     string(domain.GetDomain(err)),
+			Stacktrace: extractStacktrace(err, opts.Depth+2),
+		},
+	}
+
+	for k, v := range ts {
+		r.appendTag(k, v, evt)
+	}
+
+	return evt
+}
+
+func extractStacktrace(err error, n int) *sentry.Stacktrace {
+	var s sentry.Stacktrace
+
+	appendFrame := func(f stacktrace.Frame) {
+		fn, file, line := f.Location()
+
+		pkg, fn := splitQualifiedFunctionName(fn)
+
+		s.Frames = append(
+			s.Frames,
+			sentry.Frame{
+				AbsPath:  file,
+				Function: fn,
+				Lineno:   line,
+				Module:   pkg,
+				InApp:    isInApp(file, pkg),
+			},
+		)
+	}
+
+	appendFrame(stacktrace.Caller(n + 1))
+
+	for _, f := range stacktrace.GetFrames(err) {
+		appendFrame(f)
+	}
+
+	return &s
+}
+
+func splitQualifiedFunctionName(name string) (string, string) {
+	pkg := packageName(name)
+	return pkg, strings.TrimPrefix(name, pkg+".")
+}
+
+func packageName(name string) string {
+	// A prefix of "type." and "go." is a compiler-generated symbol that doesn't belong to any package.
+	// See variable reservedimports in cmd/compile/internal/gc/subr.go
+	if strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.") {
+		return ""
+	}
+
+	pathend := strings.LastIndex(name, "/")
+	if pathend < 0 {
+		pathend = 0
+	}
+
+	if i := strings.Index(name[pathend:], "."); i != -1 {
+		return name[:pathend+i]
+	}
+	return ""
+}
+
+func isInApp(absPath, module string) bool {
+	if strings.HasPrefix(absPath, build.Default.GOROOT) ||
+		strings.Contains(module, "vendor") ||
+		strings.Contains(module, "third_party") {
+		return false
+	}
+
+	return true
+}
+
+func stringifyTag(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+
+	switch vv := v.(type) {
+	case string:
+		return vv
+	case []byte:
+		return string(vv)
+	case fmt.Stringer:
+		return vv.String()
+	}
+
+	return fmt.Sprint(v)
+}
+
+func transactionName(tags map[string]interface{}) string {
+	if v, ok := tags[reporter.TransactionKey]; ok {
+		return stringifyTag(v)
+	}
+
+	if v, ok := tags[reporter.ThriftRequestMethodKey]; ok {
+		return fmt.Sprintf(
+			"%s#%s",
+			stringifyTag(tags[reporter.ThriftRequestServiceKey]),
+			stringifyTag(v),
+		)
+	}
+
+	if v, ok := tags[reporter.HTTPRequestPathKey]; ok {
+		return fmt.Sprintf(
+			"%s %s",
+			stringifyTag(tags[reporter.HTTPRequestMethodKey]),
+			stringifyTag(v),
+		)
+	}
+
+	return ""
+}
+
+func buildUser(tags map[string]interface{}) sentry.User {
+	return sentry.User{
+		Email: stringifyTag(tags[reporter.UserEmailKey]),
+		ID:    stringifyTag(tags[reporter.UserIDKey]),
+	}
+}
+
+func buildRequest(tags map[string]interface{}) *sentry.Request {
+	var (
+		req    sentry.Request
+		tapped bool
+
+		u   = url.URL{Scheme: "http", Host: "localhost"}
+		qvs = url.Values{}
+	)
+
+	for k, v := range tags {
+		switch {
+		case k == reporter.HTTPRequestProtoKey:
+			u.Scheme = stringifyTag(v)
+		case k == reporter.HTTPRequestPathKey:
+			u.Path = stringifyTag(v)
+		case k == reporter.HTTPRequestHostKey:
+			u.Host = stringifyTag(v)
+		case k == reporter.HTTPRequestMethodKey:
+			req.Method = stringifyTag(v)
+		case strings.HasPrefix(k, reporter.HTTPRequestHeaderKeyPrefix):
+			if req.Headers == nil {
+				req.Headers = make(map[string]string)
+			}
+
+			k := strings.TrimPrefix(k, reporter.HTTPRequestHeaderKeyPrefix)
+			req.Headers[k] = stringifyTag(v)
+		case strings.HasPrefix(k, reporter.HTTPRequestQueryValuesKeyPrefix):
+			qvs.Add(
+				strings.TrimPrefix(k, reporter.HTTPRequestQueryValuesKeyPrefix),
+				stringifyTag(v),
+			)
+		default:
+			continue
+		}
+
+		tapped = true
+	}
+
+	if tapped {
+		req.URL = u.String()
+		req.QueryString = qvs.Encode()
+
+		return &req
+	}
+
 	return nil
 }

--- a/reporter/sentry/reporter.go
+++ b/reporter/sentry/reporter.go
@@ -164,16 +164,7 @@ func stringifyTag(v interface{}) string {
 		return ""
 	}
 
-	switch vv := v.(type) {
-	case string:
-		return vv
-	case []byte:
-		return string(vv)
-	case fmt.Stringer:
-		return vv.String()
-	}
-
-	return fmt.Sprint(v)
+	return fmt.Sprintf("%s", v)
 }
 
 func transactionName(tags map[string]interface{}) string {

--- a/reporter/sentry/reporter.go
+++ b/reporter/sentry/reporter.go
@@ -41,6 +41,7 @@ func NewReporter(os ...Option) (*Reporter, error) {
 	return &Reporter{
 		cl:           cl,
 		tagWhitelist: opts.TagWhitelist,
+		tagBlacklist: opts.TagBlacklist,
 		timeout:      opts.Timeout,
 	}, nil
 }

--- a/reporter/sentry/reporter_test.go
+++ b/reporter/sentry/reporter_test.go
@@ -1,0 +1,98 @@
+package sentry
+
+import (
+	"testing"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/upfluence/errors"
+	"github.com/upfluence/errors/reporter"
+)
+
+func TestBuildEvent(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+
+		opts  []Option
+		err   error
+		ropts reporter.ReportOptions
+
+		evtfn func(*testing.T, *sentry.Event)
+	}{
+		{
+			name: "no error",
+			evtfn: func(t *testing.T, evt *sentry.Event) {
+				assert.Nil(t, evt)
+			},
+		},
+		{
+			name: "simple error",
+			err:  errors.New("basic error"),
+			evtfn: func(t *testing.T, evt *sentry.Event) {
+				assert.Equal(t, "basic error", evt.Message)
+				assert.Equal(t, "", evt.Transaction)
+				assert.Equal(
+					t,
+					map[string]string{"domain": "github.com/upfluence/errors/reporter/sentry"},
+					evt.Tags,
+				)
+				assert.Equal(t, map[string]interface{}{}, evt.Contexts)
+			},
+		},
+		{
+			name: "error transaction tag",
+			err: errors.WithTags(
+				errors.New("basic error"),
+				map[string]interface{}{reporter.TransactionKey: "transaction#27"},
+			),
+			evtfn: func(t *testing.T, evt *sentry.Event) {
+				assert.Equal(t, "basic error", evt.Message)
+				assert.Equal(t, "transaction#27", evt.Transaction)
+			},
+		},
+		{
+			name: "simple error with thrift opts",
+			err:  errors.New("basic error"),
+			ropts: reporter.ReportOptions{
+				Tags: map[string]interface{}{
+					reporter.ThriftRequestServiceKey: "svc",
+					reporter.ThriftRequestMethodKey:  "Method",
+				},
+			},
+			evtfn: func(t *testing.T, evt *sentry.Event) {
+				assert.Equal(t, "basic error", evt.Message)
+				assert.Equal(t, "svc#Method", evt.Transaction)
+			},
+		},
+		{
+			name: "simple error with http opts",
+			err:  errors.New("basic error"),
+			ropts: reporter.ReportOptions{
+				Tags: map[string]interface{}{
+					reporter.HTTPRequestMethodKey: "GET",
+					reporter.HTTPRequestPathKey:   "/foo",
+					reporter.HTTPRequestHostKey:   "example.com",
+				},
+			},
+			evtfn: func(t *testing.T, evt *sentry.Event) {
+				assert.Equal(t, "basic error", evt.Message)
+				assert.Equal(t, "GET /foo", evt.Transaction)
+				assert.Equal(
+					t,
+					&sentry.Request{URL: "http://example.com/foo", Method: "GET"},
+					evt.Request,
+				)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := NewReporter(tt.opts...)
+
+			assert.NoError(t, err)
+
+			evt := r.buildEvent(tt.err, tt.ropts)
+			tt.evtfn(t, evt)
+		})
+	}
+}

--- a/reporter/sentry/tag_integration.go
+++ b/reporter/sentry/tag_integration.go
@@ -1,0 +1,24 @@
+package sentry
+
+import "github.com/getsentry/sentry-go"
+
+type tagIntegration struct {
+	tags map[string]string
+}
+
+func (ti *tagIntegration) Name() string { return "custom_tags" }
+func (ti *tagIntegration) SetupOnce(cl *sentry.Client) {
+	cl.AddEventProcessor(ti.process)
+}
+
+func (ti *tagIntegration) process(evt *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+	if evt.Tags == nil {
+		evt.Tags = make(map[string]string, len(ti.tags))
+	}
+
+	for k, v := range ti.tags {
+		evt.Tags[k] = v
+	}
+
+	return evt
+}

--- a/stacktrace/stacktrace.go
+++ b/stacktrace/stacktrace.go
@@ -2,6 +2,7 @@ package stacktrace
 
 import (
 	"runtime"
+	"strings"
 
 	"github.com/upfluence/errors/base"
 )
@@ -50,4 +51,22 @@ func GetFrames(err error) []Frame {
 	}
 
 	return fs
+}
+
+func PackageName(name string) string {
+	// A prefix of "type." and "go." is a compiler-generated symbol that doesn't belong to any package.
+	// See variable reservedimports in cmd/compile/internal/gc/subr.go
+	if strings.HasPrefix(name, "go.") || strings.HasPrefix(name, "type.") {
+		return ""
+	}
+
+	pathend := strings.LastIndex(name, "/")
+	if pathend < 0 {
+		pathend = 0
+	}
+
+	if i := strings.Index(name[pathend:], "."); i != -1 {
+		return name[:pathend+i]
+	}
+	return ""
 }


### PR DESCRIPTION
### What does this PR do?

This is an initial implementation of an error reporter that takes avantage of the tags included both in the error and inside the context  passed.

From those tag some sentry first citizen will be built (i.e. User payload and HTTP Request payload) it should make the error reporting on sentry way more meaning full

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
