### PR TITLE
Make the sentinel error atomic

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -21,8 +21,8 @@ func PackageDomainAtDepth(depth int) Domain {
 
 func GetDomain(err error) Domain {
 	for {
-		if wd, ok := err.(*withDomain); ok {
-			return wd.domain
+		if wd, ok := err.(interface{ Domain() Domain }); ok {
+			return wd.Domain()
 		}
 
 		err = base.UnwrapOnce(err)

--- a/domain/with_domain.go
+++ b/domain/with_domain.go
@@ -8,9 +8,10 @@ type withDomain struct {
 	domain Domain
 }
 
-func (ws *withDomain) Error() string { return ws.cause.Error() }
-func (ws *withDomain) Unwrap() error { return ws.cause }
-func (ws *withDomain) Cause() error  { return ws.cause }
+func (ws *withDomain) Error() string  { return ws.cause.Error() }
+func (ws *withDomain) Unwrap() error  { return ws.cause }
+func (ws *withDomain) Cause() error   { return ws.cause }
+func (ws *withDomain) Domain() Domain { return ws.domain }
 
 func (ws *withDomain) Tags() map[string]interface{} {
 	return map[string]interface{}{"domain": string(ws.domain)}

--- a/opaque/opaque_error.go
+++ b/opaque/opaque_error.go
@@ -1,6 +1,10 @@
 package opaque
 
-import "github.com/upfluence/errors/tags"
+import (
+	"github.com/upfluence/errors/domain"
+	"github.com/upfluence/errors/stacktrace"
+	"github.com/upfluence/errors/tags"
+)
 
 type opaqueError struct {
 	cause error
@@ -8,8 +12,16 @@ type opaqueError struct {
 
 func (oe *opaqueError) Error() string { return oe.cause.Error() }
 
+func (oe *opaqueError) Domain() domain.Domain {
+	return domain.GetDomain(oe.cause)
+}
+
 func (oe *opaqueError) Tags() map[string]interface{} {
 	return tags.GetTags(oe.cause)
+}
+
+func (oe *opaqueError) Frames() []stacktrace.Frame {
+	return stacktrace.GetFrames(oe.cause)
 }
 
 func Opaque(err error) error {

--- a/stacktrace/stacktrace.go
+++ b/stacktrace/stacktrace.go
@@ -43,8 +43,11 @@ func GetFrames(err error) []Frame {
 			break
 		}
 
-		if ferr, ok := err.(interface{ Frame() Frame }); ok {
+		switch ferr := err.(type) {
+		case interface{ Frame() Frame }:
 			fs = append(fs, ferr.Frame())
+		case interface{ Frames() []Frame }:
+			fs = append(fs, ferr.Frames()...)
 		}
 
 		err = base.UnwrapOnce(err)

--- a/stats/statuser.go
+++ b/stats/statuser.go
@@ -26,7 +26,7 @@ type defaultStatuser struct{}
 
 func (defaultStatuser) Status(err error) string {
 	switch t := fmt.Sprintf("%T", err); t {
-	case "*errors.errorString", "*errors.fundamental":
+	case "*errors.errorString", "*errors.fundamental", "*opaque.opaqueError":
 		return err.Error()
 	default:
 		return t

--- a/wrap.go
+++ b/wrap.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/upfluence/errors/domain"
 	"github.com/upfluence/errors/message"
+	"github.com/upfluence/errors/opaque"
 )
 
 func New(msg string) error {
-	return domain.WithDomain(
-		WithFrame(errors.New(msg), 1),
-		domain.PackageDomainAtDepth(1),
+	return opaque.Opaque(
+		domain.WithDomain(
+			WithFrame(errors.New(msg), 1),
+			domain.PackageDomainAtDepth(1),
+		),
 	)
 }
 


### PR DESCRIPTION
### What does this PR do?

Prior to this PR the code behind `errors.New` was returning an error implenting `Cause()` and `Unwrap()` it was making the sentinel equality assertion impossible.

I wrapped the error in an opaque shell and make sure the shell expose the meta infos

Fixes: It should solve https://sentry.io/organizations/upfluence/issues/2009330934/events/da392143d517400cb1fbee1fd953fbd1/?project=220516&query=is%3Aunresolved

### What are the observable changes?


```go
var errFoo = errors.New("foo")

errors.Cause(errFoo) == errFoo // Should now be true
```

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
