### PR TITLE
 stats: try to interpret error with statuser interface

### DIFF
--- a/stats/statuser.go
+++ b/stats/statuser.go
@@ -34,6 +34,10 @@ func (defaultStatuser) Status(err error) string {
 }
 
 func GetStatus(err error, opts ...ExtractStatusOption) string {
+	type statuser interface {
+		Status() string
+	}
+
 	var o = defaultStatusOptions
 
 	for _, opt := range opts {
@@ -45,10 +49,8 @@ func GetStatus(err error, opts ...ExtractStatusOption) string {
 	}
 
 	for {
-		ws, ok := err.(*withStatus)
-
-		if ok {
-			return ws.status
+		if st, ok := err.(statuser); ok {
+			return st.Status()
 		}
 
 		cause := base.UnwrapOnce(err)

--- a/stats/with_status.go
+++ b/stats/with_status.go
@@ -5,9 +5,10 @@ type withStatus struct {
 	status string
 }
 
-func (ws *withStatus) Error() string { return ws.cause.Error() }
-func (ws *withStatus) Unwrap() error { return ws.cause }
-func (ws *withStatus) Cause() error  { return ws.cause }
+func (ws *withStatus) Error() string  { return ws.cause.Error() }
+func (ws *withStatus) Unwrap() error  { return ws.cause }
+func (ws *withStatus) Cause() error   { return ws.cause }
+func (ws *withStatus) Status() string { return ws.status }
 
 func (ws *withStatus) Tags() map[string]interface{} {
 	return map[string]interface{}{"status": ws.status}


### PR DESCRIPTION
### What does this PR do?

Try to cast errors into  `type interface { Status() string }` to retrieve the status.

### What are the observable changes?

try to type cast when unwrapping the error

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
