### PR TITLE
Add error message in the NoError assert

### DIFF
--- a/errtest/assertion.go
+++ b/errtest/assertion.go
@@ -1,6 +1,7 @@
 package errtest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +41,13 @@ func (fn ErrorAssertionFunc) Assert(t testing.TB, err error) { fn(t, err) }
 
 func NoError(msgAndArgs ...interface{}) ErrorAssertion {
 	return ErrorAssertionFunc(
-		func(t testing.TB, err error) { assert.Nil(t, err, msgAndArgs...) },
+		func(t testing.TB, err error) {
+			assert.Nil(
+				t,
+				err,
+				append([]interface{}{fmt.Sprint(err)}, msgAndArgs...),
+			)
+		},
 	)
 }
 


### PR DESCRIPTION
### What does this PR do?

Add the error message automatically to the assertion  message.  This is useful in the test log as it will provide more information when the error is wrapped.
```
Error:      	Expected nil, but got: &stacktrace.withFrame{cause:(*message.withMessage)(0xc0000761c0), frame:0x6c8d40}
Test:       	TestBatch/success/client_test
```
Becomes
```
Error:      	Expected nil, but got: &stacktrace.withFrame{cause:(*message.withMessage)(0xc000076f00), frame:0x6c8d40}
Test:       	TestBatch/success/client_test
Messages:   	[could not decode response: invalid character 'o' looking for beginning of value]
```

### Good PR checklist

- [x ] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled