### PR TITLE
multi: Add Join

### DIFF
--- a/multi.go
+++ b/multi.go
@@ -4,5 +4,4 @@ import "github.com/upfluence/errors/multi"
 
 func WrapErrors(errs []error) error { return WithFrame(multi.Wrap(errs), 1) }
 func Combine(errs ...error) error   { return WithFrame(multi.Wrap(errs), 1) }
-
-var Join = Combine
+func Join(errs ...error) error      { return WithFrame(multi.Wrap(errs), 1) }

--- a/multi.go
+++ b/multi.go
@@ -4,3 +4,5 @@ import "github.com/upfluence/errors/multi"
 
 func WrapErrors(errs []error) error { return WithFrame(multi.Wrap(errs), 1) }
 func Combine(errs ...error) error   { return WithFrame(multi.Wrap(errs), 1) }
+
+var Join = Combine


### PR DESCRIPTION
### What does this PR do?

Go 1.20 introduced [errors.Join](https://pkg.go.dev/errors#Join) which pretty much is the same as Combine.
So I think we should sync with stdlib (also that's 3 less characters to type :trollface:  ).
I didn't dare to mark "Combine" as deprecated, but perhaps it could be done in the future to encourage the use of Join?

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
